### PR TITLE
[Chore] Github-reviewer-noti action에 mattermost webhook 추가

### DIFF
--- a/.github/workflows/slack-noti.yml
+++ b/.github/workflows/slack-noti.yml
@@ -9,8 +9,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@master
       - name: Fire Notification
-        uses: Lubycon/github-reviewer-slack-noti-action@v1.3.0
+        uses: Lubycon/github-reviewer-slack-noti-action@v1.6.0
         with:
           slack-bot-token: ${{ secrets.LUBYCON_SLACK_BOT_TOKEN }}
           github-token: ${{ secrets.LUBYCON_GITHUB_TOKEN }}
           channel-id: C01SSJ6HGTH
+          mattermost-webhook: ${{ secrets.MATTERMOST_WEBHOOK_URL }}

--- a/.github/workflows/slack-noti.yml
+++ b/.github/workflows/slack-noti.yml
@@ -1,4 +1,4 @@
-name: PR Slack Notification
+name: PR Notification
 on: [pull_request, pull_request_review, pull_request_review_comment]
 
 jobs:
@@ -9,9 +9,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@master
       - name: Fire Notification
-        uses: Lubycon/github-reviewer-slack-noti-action@v1.6.0
+        uses: Lubycon/github-reviewer-noti-action@v2.0.1
         with:
-          slack-bot-token: ${{ secrets.LUBYCON_SLACK_BOT_TOKEN }}
           github-token: ${{ secrets.LUBYCON_GITHUB_TOKEN }}
-          channel-id: C01SSJ6HGTH
           mattermost-webhook: ${{ secrets.MATTERMOST_WEBHOOK_URL }}


### PR DESCRIPTION
## 내용

<!--
- 스샷을 첨부해주세요.
- 추가된 기능들의 나열.
- 포인트: 최대한 자세히 쓸 것. 내 코드 보는 사람은 지금 이 도메인 맥락을 모른다고 가정하기
- 코드에 셀프 코멘트를 달아주면 좋음!
-->

- `Lubycon/github-reviewer-slack-noti-action` -> `Lubycon/github-reviewer-noti-action`로 변경, v2.0.1로 업데이트하였습니다.
- Mattermost Webhook 추가하였습니다.